### PR TITLE
Fix genann build for CHICKEN 5.2.0

### DIFF
--- a/genann.egg
+++ b/genann.egg
@@ -3,6 +3,6 @@
  (category misc)
  (license "Zlib")
  (components
-  (c-object genann_src)
+  #;(c-object genann_src)
   (extension genann
-             (objects genann_src))))
+             #;(objects genann_src))))

--- a/genann.egg
+++ b/genann.egg
@@ -3,6 +3,6 @@
  (category misc)
  (license "Zlib")
  (components
+  (c-object genann_src)
   (extension genann
-             (csc-options "./genann_src.c"
-                          -O3 -C -O3))))
+             (objects genann_src))))

--- a/genann.scm
+++ b/genann.scm
@@ -38,6 +38,7 @@
           (only srfi-4 make-f64vector))
 
   (foreign-declare "#include \"genann.h\"")
+  (foreign-declare "#include \"genann_src.c\"")
 
   (define-record-type genann
     (ptr->genann ptr)


### PR DESCRIPTION
This egg doesn't build on the newly released 5.2.0rc1 because the -c option doesn't accept multiple file names, uponwhich this egg's build indirectly relies.

See https://bugs.call-cc.org/ticket/1655 and the commit messages for more information.